### PR TITLE
Fix Docker credential helper not found error in IntelliJ context

### DIFF
--- a/src/main/kotlin/org/boulderse/ijserver/hooks/RenameHook.kt
+++ b/src/main/kotlin/org/boulderse/ijserver/hooks/RenameHook.kt
@@ -123,26 +123,45 @@ class RenameHook : ProjectActivity {
                     ?.removePrefix(project.basePath + "/")!!,
             )
         println("Running command: ${command.joinToString(" ")}")
+        val dockerEnvOverrides = dockerManager.prepareCredentialHelperWorkaround()
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val cmd =
                     ProcessBuilder(command)
+                dockerManager.applyEnvironmentOverrides(cmd, dockerEnvOverrides)
                 cmd.environment()["GRAZIE_JWT_TOKEN"] = llmKey
                 val process = cmd.start()
-                process.waitFor()
-                val containerId =
+                val exitCode = process.waitFor()
+                val stdout =
                     process.inputStream
                         .bufferedReader()
                         .use { it.readText() }
-                        .removeSuffix("\n")
+                        .trim()
+                val stderr =
+                    process.errorStream
+                        .bufferedReader()
+                        .use { it.readText() }
+
+                if (exitCode != 0 || stdout.isBlank()) {
+                    println(
+                        "Failed to start rename agent container (exit=$exitCode). " +
+                            "stdout:\n$stdout\nstderr:\n$stderr",
+                    )
+                    return@executeOnPooledThread
+                }
+
+                val containerId = stdout
                 println("Containerid=$containerId")
 
                 logViewer.registerAgentContainerId(containerId)
-                val waitProcess = ProcessBuilder(listOf(dockerManager.dockerPath, "container", "wait", containerId)).start()
-                val exitCode = waitProcess.waitFor()
+                val waitCommand = listOf(dockerManager.dockerPath, "container", "wait", containerId)
+                val waitProcessBuilder = ProcessBuilder(waitCommand)
+                dockerManager.applyEnvironmentOverrides(waitProcessBuilder, dockerEnvOverrides)
+                val waitProcess = waitProcessBuilder.start()
+                val waitExitCode = waitProcess.waitFor()
                 val output = waitProcess.inputStream.bufferedReader().use { it.readText() }
-                val stderr = waitProcess.errorStream.bufferedReader().use { it.readText() }
-                println("refagent exit=$exitCode output:\n$output\nstderr:\n$stderr")
+                val waitStderr = waitProcess.errorStream.bufferedReader().use { it.readText() }
+                println("refagent exit=$waitExitCode output:\n$output\nstderr:\n$waitStderr")
             } catch (e: Exception) {
                 println("Failed to run refagent: ${e.message}")
             } finally {

--- a/src/main/kotlin/org/boulderse/ijserver/utils/DockerManager.kt
+++ b/src/main/kotlin/org/boulderse/ijserver/utils/DockerManager.kt
@@ -2,6 +2,9 @@ package org.boulderse.ijserver.utils
 
 import kotlinx.io.IOException
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.UUID
 
 class DockerManager {
     var dockerPath: String? = null
@@ -124,5 +127,82 @@ class DockerManager {
             if (singleton == null) singleton = DockerManager()
             return singleton!!
         }
+    }
+
+    fun prepareCredentialHelperWorkaround(): Map<String, String> {
+        if (!isCredentialHelperMissing()) return emptyMap()
+
+        return try {
+            val tempDir = Files.createTempDirectory("rename-agent-docker-${UUID.randomUUID()}")
+            val configFile = tempDir.resolve("config.json")
+            Files.writeString(configFile, "{}")
+            val configPath = tempDir.toAbsolutePath().toString()
+            println("Applying docker credential helper workaround using config at $configPath")
+            mapOf("DOCKER_CONFIG" to configPath)
+        } catch (e: Exception) {
+            println("Failed to create docker config override: ${e.message}")
+            emptyMap()
+        }
+    }
+
+    fun applyEnvironmentOverrides(
+        builder: ProcessBuilder,
+        overrides: Map<String, String>,
+    ) {
+        overrides.forEach { (key, value) ->
+            builder.environment()[key] = value
+        }
+    }
+
+    private fun isCredentialHelperMissing(): Boolean {
+        val home = System.getenv("HOME") ?: return false
+        val configPath = Paths.get(home, ".docker", "config.json")
+        if (!Files.exists(configPath)) return false
+
+        return try {
+            val config = Files.readString(configPath)
+            val helperNames =
+                mutableSetOf<String>().apply {
+                    Regex("\"credsStore\"\\s*:\\s*\"([^\"]+)\"")
+                        .find(config)
+                        ?.let { add(it.groupValues[1]) }
+                    Regex("\"credHelpers\"\\s*:\\s*\\{([^}]*)}")
+                        .find(config)
+                        ?.groupValues
+                        ?.getOrNull(1)
+                        ?.let { helpersBody ->
+                            Regex("\"[^\"]+\"\\s*:\\s*\"([^\"]+)\"")
+                                .findAll(helpersBody)
+                                .forEach { add(it.groupValues[1]) }
+                        }
+                }
+
+            helperNames.any { helper ->
+                val executable = "docker-credential-$helper"
+                val helperMissing = !isExecutableOnPath(executable)
+                if (helperMissing) {
+                    println("Detected docker credential helper '$executable' configured but not present on PATH.")
+                }
+                helperMissing
+            }
+        } catch (e: Exception) {
+            println("Failed to inspect docker config for credential helpers: ${e.message}")
+            false
+        }
+    }
+
+    private fun isExecutableOnPath(executable: String): Boolean {
+        val path = System.getenv("PATH") ?: return false
+        val isWindows = System.getProperty("os.name").lowercase().contains("win")
+
+        return path
+            .split(File.pathSeparatorChar)
+            .filter { it.isNotBlank() }
+            .any { dir ->
+                val candidate = File(dir, executable)
+                val candidateWithExe = if (isWindows) File(dir, "$executable.exe") else null
+                (candidate.exists() && candidate.canExecute()) ||
+                    (candidateWithExe?.let { it.exists() && it.canExecute() } ?: false)
+            }
     }
 }


### PR DESCRIPTION
Add detection for missing docker-credential-* executables and create temporary Docker config override to bypass credential helpers when running docker commands from plugin. Only applies workaround when helpers are actually missing from PATH.